### PR TITLE
ajout non responsabilités si erreurs

### DIFF
--- a/frontend/src/components/Legal.vue
+++ b/frontend/src/components/Legal.vue
@@ -54,32 +54,39 @@
               <p>Emmanuel Barbe, délégué interministériel à la Sécurité routière </p>
               <h5>Crédits</h5>
               <p>Le ministère de l'Intérieur est titulaire des droits relatifs à la propriété intellectuelle des contenus (infographies et autres éléments techniques et graphiques), disponibles sur le site histovec.gouv.fr.</p>
-              <p>Sauf mention contraire, les photographies et vidéos sont libres de droits, issues du site picjumbo.com.</p> 
               <p>Ces éléments sont couverts par des droits de propriété intellectuelle de tiers. En application du code de la propriété intellectuelle, toute reproduction ou représentation partielle ou totale pour quelque usage que ce soit est interdite sans l'accord préalable des titulaires de droits. Pour toute demande de reproduction, <a href="contact">contactez-nous.</a></p>
-              <h5>Conception et réalisation</h5>
-              Conception et réalisation Lab DSIC avec le Bureau des immatriculations (DSR)
-              <p></p>
-              <h5>Établir un lien avec le site de la Sécurité routière </h5>
+              <p>Sauf mention contraire, les photographies sont issues du site <a href="http://picjumbo.">picjumbo.com</a> et libres de droits.</p>
+          <h5>Conception et réalisation</h5>
+              Conception et réalisation Lab <a href="https://www.interieur.gouv.fr/Le-ministere/Secretariat-general/Direction-des-systemes-d-information-et-de-communication">DSIC</a> du ministère de l'Intérieur avec le Bureau des immatriculations (<a href="http://www.securite-routiere.gouv.fr/la-securite-routiere/qui-sommes-nous/la-delegation-a-la-securite-routiere">DSR</a>)
+
               <h6> Liens hypertextes entrants </h6>
               Tout site public ou privé est autorisé à établir, sans autorisation préalable, un lien vers les informations diffusées dans ce site.
               En revanche les pages du site histovec.interieur.gouv.fr ne doivent pas être imbriquées à l’intérieur des pages d’un autre site : rien ne doit méprendre le visiteur sur l’origine d’une page vue.
               Le ministère de l'Intérieur se réserve le droit de demander la suppression d'un lien qu'elle estime non-conforme à l'objet du site, à ses missions ou plus généralement à l'éthique d'un portail public.
-              L’autorisation de mise en place d’un lien est valable pour tout support, à l’exception de ceux diffusant des informations à caractère polémique, pornographique, xénophobe ou pouvant, dans une plus large mesure porter atteinte à la sensibilité du plus grand nombre
+              L’autorisation de mise en place d’un lien est valable pour tout support, à l’exception de ceux diffusant des informations à caractère polémique, pornographique, xénophobe ou pouvant, dans une plus large mesure, porter atteinte à la sensibilité du plus grand nombre.
               <p></p>
               <h6> Liens hypertextes sortants </h6>
-              Le site indique en permanence l'identité des sites indiqués en lien, et ce sur toutes les pages. Néanmoins, ces pages web dont les adresses URL sont régulièrement vérifiées ne font pas partie du site et par conséquent n'engagent en rien la responsabilité du site histovec.interieur.gouv.fr.
+              Le site indique en permanence l'identité des sites externes indiqués en lien, et ce sur toutes les pages. Néanmoins, ces pages web dont les adresses URL sont régulièrement vérifiées ne font pas partie du site et par conséquent n'engagent en rien la responsabilité du site histovec.interieur.gouv.fr.
               <h6>Stabilité des adresses</h6>
               Nous essayons de maintenir des adresses URL de page stables. Toutefois, ce site pouvant faire à tout moment l’objet de réorganisations, nous ne pouvons pas garantir la stabilité de l’adresse des pages internes du site.
               <h6>Droit d’auteur</h6>
-              Les contenus disponibles sur ce site sont protégés par le droit d’auteur. Au terme de l’article L. 122-4 du cCode de la propriété intellectuelle, vous ne pouvez reproduire tout ou partie de ces œuvres sans en avoir obtenu l’autorisation expresse au préalable.
+              Les contenus disponibles sur ce site sont protégés par le droit d’auteur. Au terme de l’article L. 122-4 du Code de la propriété intellectuelle, vous ne pouvez reproduire tout ou partie de ces œuvres sans en avoir obtenu l’autorisation expresse au préalable.
               <h6>Code applicatif open source</h6>
               Conformément à la <a href="https://www.legifrance.gouv.fr/affichLoiPubliee.do?idDocument=JORFDOLE000031589829&type=general&legislature=14">loi pour une République numérique</a>, le code de l'application Histovec est libre et opensource, publié sous <a href="https://www.gnu.org/licenses/lgpl-3.0.fr.html">licence LGPL</a>.
               <h6>Limitations de responsabilité</h6>
               Le site HistoVec fournit les informations issues du Système d’Immatriculation des Véhicules (SIV).
+              La responsabilité de l'Editeur ne peut être engagée sur des inexactitudes concernant les informations fournies, qu’elles proviennent d’erreurs issues du Système d’Immatriculation des Véhicules, ou d’anomalies de traitement informatique.
+              Le droit d’accès, de modification, de rectification et de suppression des données du Système d’Immatriculation des Véhicules s’exerce en justifiant son identité, par voie postale.  :
+              Agence Nationale des Titres Sécurisés
+              18 rue Irénée Carré
+              BP 70474
+              08101 Charleville-Mézières
+
+
               <h6>Accessibilité</h6>
-              Le ministère de l’Intérieur s’efforce de permettre que les internautes puissent avoir accès en continu au site.
-              Néanmoins, l ministère de l’Intérieur se réserve le droit de ne pouvoir garantir l’accessibilité à son site internet et à l’ensemble des téléservices proposés en cas de force majeur (panne, intention technique de maintenance). La responsabilité du ministère ne pourrait être engagée.
-              Site optimisé pour Firefox 45+ et Chrome 50+
+              Le ministère de l’Intérieur s’efforce de donner accès en continu au site.
+              Néanmoins, la responsabilité du ministère de l’Intérieur ne peut être engagée en cas de non accessibilité à son site internet et à l’ensemble des téléservices proposés.
+              Site optimisé pour Firefox 45+ et Chrome 50+.
               <h6>Propriété intellectuelle et droits d'utilisation</h6>
               L'utilisateur s'engage, sous peine de voir sa responsabilité civile et/ou pénale engagée, à ne pas utiliser le site Internet de l’éditeur pour :
               <ul>


### PR DESCRIPTION
Pour se prémunir d'actions de vendeurs ou acheteurs qui se considèreraient lésés par des inexactitudes sur HistoVec ? qu'elles viennent du SIV, ou de bug appli d'HistoVec