### PR TITLE
security fix for webpack

### DIFF
--- a/frontend/package.json.template
+++ b/frontend/package.json.template
@@ -68,7 +68,7 @@
     "hoek": "^6.1.3",
     "less": "^3.0.4",
     "less-loader": "^4.0.3",
-    "node-sass": "^4.9.0",
+    "node-sass": "^4.11.0",
     "opn": "^4.0.2",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "ora": "^1.1.0",
@@ -81,7 +81,7 @@
     "vue-style-loader": "^2.0.0",
     "vue-template-compiler": "^2.3.3",
     "webpack": "^4.29.6",
-    "webpack-bundle-analyzer": "^2.13.1",
+    "webpack-bundle-analyzer": "^3.3.2",
     "webpack-dev-middleware": "^3.6.1",
     "webpack-hot-middleware": "^2.24.3",
     "webpack-merge": "^4.1.3"


### PR DESCRIPTION
another sec fix (node-sass/node-gyp/tar isn't properly fixed, as node-gyp didn't publish the package 4.x: https://github.com/nodejs/node-gyp/issues/1721)