### PR TITLE
buyer/decrypt-error-message

### DIFF
--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -37,15 +37,22 @@ const decrypt = (encrypted, key) => {
       })
   } catch (e) {
     /* eslint-disable-next-line no-console */
-    console.log(encrypted, e)
-    throw new Error('decrypt_error')
+    console.log('decrypt_error', e)
+    throw new Error(`decrypt_error: ${e}`)
   }
   try {
-    return JSON.parse(decrypted.toString(CryptoJS.enc.Utf8).replace(/: (0[0-9]+)/g, ': "$1"'))
+    decrypted = decrypted.toString(CryptoJS.enc.Utf8).replace(/: (0[0-9]+)/g, ': "$1"')
   } catch (e) {
     /* eslint-disable-next-line no-console */
-    console.log(decrypted.toString(CryptoJS.enc.Utf8), e)
-    throw new Error('invalid_json')
+    console.log('decrypt_toString_failure', e)
+    throw new Error(`decrypt_toString_failure: ${e}`)
+  }
+  try {
+    return JSON.parse(decrypted)
+  } catch (e) {
+    /* eslint-disable-next-line no-console */
+    console.log('decrypt_JSON_parse_error', e)
+    throw new Error(`decrypt_JSON_parse_error: ${e}`)
   }
 }
 
@@ -158,7 +165,7 @@ const decryptHit = async (apiName, response, objectPath, key) => {
   } catch (error) {
     store.commit('updateApiStatus', {
       decrypted: { [apiName]: false },
-      error: { [apiName]: { decrypt: error } }
+      error: { [apiName]: { decrypt: error.toString() } }
     })
     return {
       success: false,

--- a/frontend/src/assets/json/messages.json
+++ b/frontend/src/assets/json/messages.json
@@ -22,5 +22,17 @@
   "unavailable": "Le service Histovec n'est pas disponible pour le moment. Veuillez réessayer ultérieurement.",
   "invalidKey": "Le lien transmis est incomplet : veuillez redemander le lien complet à votre vendeur.",
   "tooManyRequests": "Trop de requêtes pour le moment. Veuillez attendre quelques instants puis réessayez.",
+  "decryptError": "Problème dans l'ouverture du rapport sécurisé - sollicitez nous.",
+  "decryptErrorBuyer": {
+    "msg": "Le rapport a été trouvé, mais la clé pour l'ouvrir est invalide : veuillez redemander le lien ou le QR-code à votre vendeur.",
+    "class": "alert alert-icon alert-danger",
+    "icon": "fa fa-warning",
+    "ref": {
+      "msg": "Besoin d'aide",
+      "route": "faq",
+      "hash": "#acheteur-le-lien-fourni-ne-fonctionne-pas",
+      "icon": "fa fa-question-circle fa-lg"
+    }
+  },
   "error": "Erreur inconnue - sollicitez nous."
 }

--- a/frontend/src/components/Report.vue
+++ b/frontend/src/components/Report.vue
@@ -323,7 +323,7 @@ export default {
       } else if (!this.$store.state.api.hit.histovec) {
         return 'notFound'
       } else if (!this.$store.state.api.decrypted.histovec) {
-        return 'error'
+        return this.holder ? 'decryptError' : 'decryptErrorBuyer'
       }
       return 'error'
     },

--- a/frontend/src/components/infos/faq-content.js
+++ b/frontend/src/components/infos/faq-content.js
@@ -353,6 +353,22 @@ export default function (mailBody) {
         <li>Télécharger le certificat de situation administrative détaillé (CSA ; téléchargeable en cliquant sur Transmettre le rapport).</li>
       </ul>
       `
+    },
+    {
+      title: 'Acheteur: le lien fourni ne fonctionne pas',
+      body: `
+      <p class="indented">
+      Le titulaire du véhicule vous a transmis un lien, celui-ci ne fonctionne pas.
+      </p>
+      <p class="indented">
+      Si HistoVec signale <b>"Le rapport a été trouvé, mais la clé pour l'ouvrir est invalide"</b>:
+      Il convient de demander une nouvelle fois le lien au titulaire du véhicule. la clé figurant dans le lien a été tronquée ou mal copiée. Un envoi du QR-Code pourrait facilier la tranmission
+      du rapport. 
+      </p>
+      <p class="indented">
+      Si jamais le problème persite avec votre vendeur : <a href="mailto:histovec@interieur.gouv.fr?subject=Signaler%20une%20erreur%20de%20lien%20invalide">contactez-nous</a>
+      </p>
+      `
     }
   ]
 


### PR DESCRIPTION
Gestion du cas où le déchiffrement n'est pas possible pour l'acheteur, lorsque la clé n'est pas valide.
Le cas le plus probable est une mauvaise transmission du lien par le vendeur.
Une section dédiée est crée dans la FAQ pour gérer le support sur ce cas auprès de l'acheteur.