### PR TITLE
fix #643 ie 11 and safari 10.1 compat

### DIFF
--- a/frontend/build/webpack.base.conf.js
+++ b/frontend/build/webpack.base.conf.js
@@ -54,7 +54,7 @@ module.exports = {
         exclude: function(modulePath) {
           return (
             /node_modules/.test(modulePath) &&
-            !/node_modules\/@sindresorhus/.test(modulePath)
+            ! /node_modules\/whatwg-fetch/.test(modulePath)
           )
         },
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,10 +16,10 @@
     "chart.js": "^2.8.0",
     "core-js": "^2.6.5",
     "crypto-js": "^3.1.9-1",
-    "delay": "^4.2.0",
     "detect-browser": "^4.5.0",
+    "es6-promise":"^4.2.6",
     "font-awesome": "^4.7.0",
-    "jspdf": "1.5.3",
+    "jspdf": "1.4.1",
     "lodash.orderby": "^4.6.0",
     "moment": "^2.24.0",
     "qr.js": "^0.0.0",
@@ -33,7 +33,7 @@
     "vue-shortkey": "^3.1.7",
     "vue-the-mask": "^0.11.1",
     "vuex": "^3.1.1",
-    "vuex-persist": "^2.0.0",
+    "vuex-persist": "1.8.0",
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {

--- a/frontend/src/components/infos/Faq.vue
+++ b/frontend/src/components/infos/Faq.vue
@@ -88,7 +88,7 @@
 <script>
 import Accordion from '@/components/infos/Accordion'
 import faqContent from './faq-content'
-import delay from 'delay'
+// import delay from 'delay'
 import { detect } from 'detect-browser'
 
 export default {
@@ -178,9 +178,11 @@ export default {
     async highlightQuestion(id) {
       const hash = `#${id}`
       this.activeQuestion = id
-      await delay(10)
-      this.$scrollTo(hash)
-      this.$router.push({ name: 'faq', hash })
+      // await delay(10)
+      setTimeout(() => {
+        this.$scrollTo(hash)
+        this.$router.push({ name: 'faq', hash })
+      }, 10)
     }
   },
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,5 +1,6 @@
 // The Vue build version to load with the `import` command
 // (runtime-only or standalone) has been set in webpack.base.conf with an alias.
+import 'es6-promise/auto'
 import Vue from 'vue'
 import App from './App'
 import router from './router'


### PR DESCRIPTION
safari 10.1 & ie 11 : home, search, report and CSA working
safari 9 & ie 10 : seem to work
ie9 coudn't be test (lambdatest isn't working for now on ie9)
ie8 ko (but ok: blank page with a message)

- `delay` deleted
- `jspdf` fixed to 1.4.1 (1 version ago)
- `vue-persist` fixed to 1.8.0 (1 version ago)
- es6-promised manually included

should consider further to do cleaner polyfill with vue-cli3 and test upgrades again
or to cancel support on ie 11 and safari 10 in some months
