### PR TITLE
fix/bug-buyer-report 

### DIFF
--- a/frontend/src/components/Report.vue
+++ b/frontend/src/components/Report.vue
@@ -431,8 +431,9 @@ export default {
           this.$route.path + '/' + (this.holder ? 'holder' : 'buyer') + '/cached')
         return
       } else {
-        if ((!this.holder && this.$route.query.key === undefined && this.$route.query.id !== undefined) ||
-            (this.$route.params.id === undefined || this.$route.params.key === undefined)) {
+        if ((!this.holder && !this.$route.query.key && this.$route.query.id) ||
+            ((!this.$route.query.id && !this.$route.params.id) ||
+            (!this.$route.query.key && !this.$route.params.key))) {
           await this.$store.dispatch('log',
             this.$route.path + '/' + (this.holder ? 'holder' : 'buyer') + '/invalid')
           return


### PR DESCRIPTION
fix  #867
Cas / test
- si un vendeur trouve son véhicule / ok
- si un vendeur ne trouve pas son véhicule, puis fait un F5, l'erreur doit être "données invalides", et aucune requête ne doit être envoyée / ok
- si un utilisateur saisit l'url http://localhost/histovec/report, l'erreur doit être "données invalides", et aucune requête ne doit être envoyée / ok
- si un acheteur entre son lien complet (clé + rapport), il doit obtenir son rapport / ok
- si un acheteur entre un lien incomplet, sans la clé, il doit recevoir l'erreur "lien invalide" et aucune requete de ne doit être envoyée / ok
- si un acheteur entre un lien incomplet, avec une clé invalide, la requête doit être faite et il doit recevoir l'erreur de clé invalide / ok
