### PR TITLE
Tech/cron update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ export PORT=80
 export APP=histovec
 export COMPOSE_PROJECT_NAME=${APP}
 export APP_PATH := $(shell pwd)
+export APP_USER := $(shell whoami)
 export APP_VERSION	:= $(shell git describe --tags || cat VERSION )
 export LOGS=${APP_PATH}/log
 # build options
@@ -406,7 +407,10 @@ git-pull:
 	git pull origin dev
 
 update: git-pull build-if-necessary up
-	
+
+install-cron:
+	@echo installing cron in /etc/cron.d
+	@echo "* * * * * ${APP_USER} /usr/bin/make -C ${APP_PATH} update" | sudo tee /etc/cron.d/${APP}
 
 build-dir:
 	if [ ! -d "$(BUILD_DIR)" ] ; then mkdir -p $(BUILD_DIR) ; fi

--- a/Makefile
+++ b/Makefile
@@ -290,6 +290,10 @@ down-fake: smtp-fake-stop utac-fake-stop down
 # package for production mode
 build: frontend-build backend-build
 
+build-if-necessary:
+	@if [ ! -f "${BACKEND}/$(FILE_BACKEND_APP_VERSION)" ]; then make frontend-build ; else echo "backend was already built"; fi
+	@if [ ! -f "${FRONTEND}/$(FILE_FRONTEND_APP_VERSION)" ]; then make backend-build ; else echo "frontend was already built"; fi
+
 build-all: build save-images
 
 save-images: elasticsearch-save-image nginx-save-image backend-save-image redis-save-image


### PR DESCRIPTION
Préco: à merger après la MEP de fix fonctionnel

Car impact très limité, mais existant, sur la procédure de déploiement (uniquement phase de build, sera validé par l'autodeploy du dev sur le cloud MI). 

Ajout de plusieurs features devops, utiles pour installer rapidement un serveur autonome histovec se mettant à jour automatiquement : 

- git-pull : fait le git pull sur la base dev
- build-if-necessary: ne build que si n'a pas déjà été buildé
- frontend/backend-check-image: vérifier que l'image docker de la version est présente
- frontend/backend-build-(un)lock: lockers pour éviter des builds paralleles
- update: run la dernière version après pull et build-if-necessary
- install-cron: ajoute un cron pour fait un check sur git chaque minute et build le cas échéant

