### PR TITLE
Fix(RGAA-8.2): validator et suppression css inutilisé

### DIFF
--- a/frontend/src/views/AccessibilitePage.vue
+++ b/frontend/src/views/AccessibilitePage.vue
@@ -173,29 +173,31 @@ export default defineComponent({
             validator.w3.org
           </a>
         </li>
-        <li>Vérification des contrastes de couleur :</li>
-        <ul class="fr-ml-4w  fr-pl-0 sous-liste">
-          <li>
-            <a
-              class="fr-link"
-              href="https://webaim.org/resources/contrastchecker/"
-              rel="noopener noreferrer"
-              title="webaim.org"
-              target="_blank"
-            >
-              https://webaim.org/resources/contrastchecker/
-            </a>
-          </li>
-          <li>WCAG Contrast checker (plugin)</li>
-        </ul>
+        <li>Vérification des contrastes de couleur :
+          <ul class="fr-ml-4w  fr-pl-0 sous-liste">
+            <li>
+              <a
+                class="fr-link"
+                href="https://webaim.org/resources/contrastchecker/"
+                rel="noopener noreferrer"
+                title="webaim.org"
+                target="_blank"
+              >
+                https://webaim.org/resources/contrastchecker/
+              </a>
+            </li>
+            <li>WCAG Contrast checker (plugin)</li>
+          </ul>
+        </li>
         <li>Désactivation du JavaScript : JavaScript Switcher</li>
         <li>Outillage web : Web Developer (plugin)</li>
-        <li>Outils d’évaluation de pages web (plugins) :</li>
-        <ul class="fr-ml-4w  fr-pl-0 sous-liste">
-          <li>Tanaguru webext</li>
-          <li>Axe DevTools</li>
-          <li>Wave (webaim)</li>
-        </ul>
+        <li>Outils d’évaluation de pages web (plugins) :
+          <ul class="fr-ml-4w  fr-pl-0 sous-liste">
+            <li>Tanaguru webext</li>
+            <li>Axe DevTools</li>
+            <li>Wave (webaim)</li>
+          </ul>
+        </li>
       </ul>
       <h4 class="fr-blue-title">
         Pages du site ayant fait l’objet de la vérification de conformité
@@ -287,16 +289,13 @@ export default defineComponent({
 </template>
 
 <style scoped>
-/* @todo centralize these rules in common CSS file as a .histovec-fr-title-link class */
+
 [href] {
   background-image: none;
 }
 
-.fr-title-link {
-  text-decoration: none;
-  color: var(--blue-france-sun-113-625);
-}
 .sous-liste {
   list-style-type: circle;
 }
+
 </style>


### PR DESCRIPTION
Erreur w3c : Error: Element [ul](https://html.spec.whatwg.org/multipage/#the-ul-element) not allowed as child of element [ul](https://html.spec.whatwg.org/multipage/#the-ul-element) in this context. (Suppressing further errors from this subtree.)