### PR TITLE
fix(RGAA): retirer id vide

### DIFF
--- a/frontend/src/components/ImagePresentation.vue
+++ b/frontend/src/components/ImagePresentation.vue
@@ -7,7 +7,7 @@ export default defineComponent({
   props: {
     id: {
       type: String,
-      default: '',
+      default: null,
     },
     alt: {
       type: String,


### PR DESCRIPTION
Validator w3c: Error: Bad value for attribute id on element [img]. An ID must not be the empty string.